### PR TITLE
fix(ui): DB kesintisinde yanıltıcı boş liste yerine uyarı

### DIFF
--- a/blog/messages/en.json
+++ b/blog/messages/en.json
@@ -23,6 +23,12 @@
     "contactAddress": "Address",
     "contactWebsite": "Website"
   },
+  "Service": {
+    "Unavailable": {
+      "title": "Content is temporarily unavailable",
+      "description": "The database cannot be reached right now. Your posts and projects were not deleted; they will show up again once connectivity is restored."
+    }
+  },
   "Blog": {
     "title": "Blog",
     "description": "Published articles and updates.",

--- a/blog/messages/tr.json
+++ b/blog/messages/tr.json
@@ -23,6 +23,12 @@
     "contactAddress": "Adres",
     "contactWebsite": "Web sitesi"
   },
+  "Service": {
+    "Unavailable": {
+      "title": "İçerik geçici olarak yüklenemiyor",
+      "description": "Veritabanına şu an ulaşılamıyor. Eklediğiniz yazılar ve projeler silinmedi; bağlantı düzelince yeniden görünecek."
+    }
+  },
   "Blog": {
     "title": "Bloglar",
     "description": "Yayınlanmış blog yazıları ve güncellemeler.",

--- a/blog/src/app/[locale]/(main)/blog/page.tsx
+++ b/blog/src/app/[locale]/(main)/blog/page.tsx
@@ -3,6 +3,7 @@ import BlogsFeature from './_features/Blogs';
 import PaginationComponent from '@/components/pagination';
 import BlogSearch from '@/components/blog/BlogSearch';
 import TaxonomyFilter from '@/components/blog/TaxonomyFilter';
+import { ContentUnavailableNotice } from '@/components/layout/content-unavailable-notice';
 import { getPublishedBlogs } from '@/lib/data/blogs';
 import { withPublicDataFallback } from '@/lib/data/with-public-data-fallback';
 import { getAllCategories, getAllTags } from '@/lib/blog-taxonomy';
@@ -49,7 +50,7 @@ async function page({ params, searchParams }: Props) {
   const category = resolvedSearchParams.category;
   const t = await getTranslations('Blog');
 
-  const [tags, categories, { data: blogData, total }] = await Promise.all([
+  const [tags, categories, blogResult] = await Promise.all([
     getAllTags(),
     getAllCategories(),
     withPublicDataFallback(
@@ -64,27 +65,34 @@ async function page({ params, searchParams }: Props) {
       { data: [], total: 0, page: currentPage, limit },
     ),
   ]);
+  const { data: blogData, total } = blogResult.value;
 
   return (
     <>
       <HeaderTemplate title={t('title')} description={t('description')} />
-      <BlogSearch initialQuery={query} />
-      <TaxonomyFilter
-        tags={tags}
-        categories={categories}
-        activeTag={tag}
-        activeCategory={category}
-      />
-      <BlogsFeature key={locale} data={blogData} />
-      <PaginationComponent
-        total={total}
-        currentPage={currentPage}
-        limit={limit}
-        isShowPagination={total > limit}
-        searchQuery={query || undefined}
-        activeTag={tag}
-        activeCategory={category}
-      />
+      {blogResult.unavailable ? (
+        <ContentUnavailableNotice />
+      ) : (
+        <>
+          <BlogSearch initialQuery={query} />
+          <TaxonomyFilter
+            tags={tags}
+            categories={categories}
+            activeTag={tag}
+            activeCategory={category}
+          />
+          <BlogsFeature key={locale} data={blogData} />
+          <PaginationComponent
+            total={total}
+            currentPage={currentPage}
+            limit={limit}
+            isShowPagination={total > limit}
+            searchQuery={query || undefined}
+            activeTag={tag}
+            activeCategory={category}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/blog/src/app/[locale]/(main)/page.tsx
+++ b/blog/src/app/[locale]/(main)/page.tsx
@@ -10,6 +10,7 @@ import { JsonLd } from '@/components/json-ld';
 import { buildPersonJsonLd, buildWebSiteJsonLd } from '@/lib/json-ld';
 import { Button } from '@/components/ui/button';
 import { SiteContactDetails } from '@/components/layout/site-contact-details';
+import { ContentUnavailableNotice } from '@/components/layout/content-unavailable-notice';
 import { getSiteOwner } from '@/lib/site-owner';
 
 export async function generateMetadata({
@@ -102,7 +103,7 @@ export default async function HomePage({
   const t = await getTranslations('HomePage');
   const tProject = await getTranslations('Pages.Project');
 
-  const [{ data: recentBlogs, total: postsTotal }, projects, topicsCount, siteOwner] =
+  const [blogsResult, projectsResult, topicsResult, siteOwner] =
     await Promise.all([
       withPublicDataFallback(
         'home.recentBlogs',
@@ -118,12 +119,21 @@ export default async function HomePage({
       getSiteOwner(),
     ]);
 
+  const { data: recentBlogs, total: postsTotal } = blogsResult.value;
+  const projects = projectsResult.value;
+  const topicsCount = topicsResult.value;
+  const contentUnavailable =
+    blogsResult.unavailable ||
+    projectsResult.unavailable ||
+    topicsResult.unavailable;
+
   const featuredProjects = projects.slice(0, 3);
 
   return (
     <div className="space-y-12 py-6 md:py-8">
       <JsonLd data={buildWebSiteJsonLd(locale)} />
       <JsonLd data={buildPersonJsonLd(siteOwner)} />
+      {contentUnavailable ? <ContentUnavailableNotice /> : null}
       <section className="relative overflow-hidden rounded-2xl border border-border/60 bg-card/50 p-8 shadow-sm backdrop-blur-sm md:p-10">
         <div
           className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-teal-500/15 blur-3xl"

--- a/blog/src/app/[locale]/(main)/project/page.tsx
+++ b/blog/src/app/[locale]/(main)/project/page.tsx
@@ -4,6 +4,7 @@ import { FeatureCard } from '@/components/layout/feature-card';
 import BlogImage from '@/components/blog/BlogImage';
 import ProjectCard from '@/components/project/ProjectCard';
 import { Link } from '@/navigation';
+import { ContentUnavailableNotice } from '@/components/layout/content-unavailable-notice';
 import { getPublishedProjectsPaginated } from '@/lib/data/projects';
 import { withPublicDataFallback } from '@/lib/data/with-public-data-fallback';
 import type { ProjectDto } from '@/lib/project-mapper';
@@ -96,11 +97,12 @@ export default async function ProjectPage({
   const currentPage = parsePage(resolvedSearchParams.page);
   const limit = parseLimit(resolvedSearchParams.limit ?? DEFAULT_PAGE_SIZE);
   const t = await getTranslations('Pages.Project');
-  const { data: projects, pagination } = await withPublicDataFallback(
+  const projectResult = await withPublicDataFallback(
     'project.list',
     () => getPublishedProjectsPaginated(locale, currentPage, limit),
     buildPaginatedResult([], currentPage, limit, 0),
   );
+  const { data: projects, pagination } = projectResult.value;
 
   const showFeatured = currentPage === 1 && projects.length > 0;
   const featured = showFeatured ? projects[0] : null;
@@ -111,7 +113,9 @@ export default async function ProjectPage({
     <>
       <HeaderTemplate title={t('title')} description={t('description')} />
 
-      {hasProjects ? (
+      {projectResult.unavailable ? (
+        <ContentUnavailableNotice />
+      ) : hasProjects ? (
         <section key={locale} className="space-y-6">
           <div className="flex flex-wrap items-end justify-between gap-3">
             <div className="space-y-1">

--- a/blog/src/components/layout/content-unavailable-notice.tsx
+++ b/blog/src/components/layout/content-unavailable-notice.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from '@/components/layout/empty-state';
+import { getTranslations } from 'next-intl/server';
+import { DatabaseZap } from 'lucide-react';
+
+export async function ContentUnavailableNotice() {
+  const t = await getTranslations('Service.Unavailable');
+
+  return (
+    <div className="mt-8">
+      <EmptyState
+        title={t('title')}
+        description={t('description')}
+        icon={DatabaseZap}
+      />
+    </div>
+  );
+}

--- a/blog/src/components/layout/empty-state.tsx
+++ b/blog/src/components/layout/empty-state.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@/navigation';
 import { Button } from '@/components/ui/button';
-import { FileQuestion } from 'lucide-react';
+import { FileQuestion, type LucideIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 
 type EmptyStateProps = {
@@ -8,6 +8,7 @@ type EmptyStateProps = {
   description: string;
   actionLabel?: string;
   actionHref?: '/' | '/blog';
+  icon?: LucideIcon;
   children?: ReactNode;
 };
 
@@ -16,12 +17,13 @@ export function EmptyState({
   description,
   actionLabel,
   actionHref = '/',
+  icon: Icon = FileQuestion,
   children,
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 bg-card/40 px-6 py-16 text-center">
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-teal-500/10 text-teal-600 dark:text-teal-400">
-        <FileQuestion className="h-7 w-7" />
+        <Icon className="h-7 w-7" />
       </div>
       <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
       <p className="mt-2 max-w-md text-sm text-muted-foreground">{description}</p>

--- a/blog/src/lib/data/with-public-data-fallback.test.ts
+++ b/blog/src/lib/data/with-public-data-fallback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { withPublicDataFallback } from '@/lib/data/with-public-data-fallback';
+import { logger } from '@/lib/logger';
+
+describe('withPublicDataFallback', () => {
+  it('returns query value when successful', async () => {
+    const result = await withPublicDataFallback('ok', async () => [1, 2], []);
+    expect(result).toEqual({ value: [1, 2], unavailable: false });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('marks unavailable and returns fallback on failure', async () => {
+    const result = await withPublicDataFallback(
+      'fail',
+      async () => {
+        throw new Error('db down');
+      },
+      [],
+    );
+
+    expect(result).toEqual({ value: [], unavailable: true });
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/blog/src/lib/data/with-public-data-fallback.ts
+++ b/blog/src/lib/data/with-public-data-fallback.ts
@@ -1,20 +1,26 @@
 import { logger } from '@/lib/logger';
 
+export type PublicDataResult<T> = {
+  value: T;
+  /** true ise sorgu DB/altyapı hatası nedeniyle fallback döndü; içerik silinmiş değildir. */
+  unavailable: boolean;
+};
+
 /**
  * Public Server Component sorgularında DB kesintisini sayfa çöküşüne çevirme.
- * Hata loglanır; çağıran boş/degraded UI gösterebilir.
+ * Hata loglanır; çağıran boş liste yerine "geçici olarak yüklenemiyor" gösterebilir.
  */
 export async function withPublicDataFallback<T>(
   label: string,
   query: () => Promise<T>,
   fallback: T,
-): Promise<T> {
+): Promise<PublicDataResult<T>> {
   try {
-    return await query();
+    return { value: await query(), unavailable: false };
   } catch (error) {
     logger.error(`Public data query failed: ${label}`, {
       error: error instanceof Error ? error.message : 'Unknown error',
     });
-    return fallback;
+    return { value: fallback, unavailable: true };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Neden içerik görünmüyor?

Üretimde `/api/health` hâlâ `db: error` dönüyor. Blog/proje verileri silinmedi; veritabanı bağlantısı kopuk olduğu için listeler boş geliyordu ve UI “henüz yok / bulunamadı” diyordu.

## Bu PR

DB hatasında boş liste yerine net uyarı:

> İçerik geçici olarak yüklenemiyor… Eklediğiniz yazılar ve projeler silinmedi.

## Sizin yapmanız gereken

Vercel + Neon tarafında `POSTGRES_PRISMA_URL` / pooler bağlantısını kontrol edin (paused proje, yanlış URL, connection limit). `/api/health` yeniden `db: ok` olunca içerikler geri gelir.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7ad1-9f87-726e-94ac-48d22a2eb6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7ad1-9f87-726e-94ac-48d22a2eb6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

